### PR TITLE
Replace article-converter with learningpath-api

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,10 +8,10 @@
 
 const whitelist = [
   'article-api',
-  'article-converter',
   'audio-api',
   'concept-api',
   'image-api',
+  'learningpath-api',
   'oembed-proxy',
   'search-api',
 ];


### PR DESCRIPTION
Treng ikkje article-converter i whitelist lenger.