### PR TITLE
Update to support openapi 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "http-status": "^1.6.1",
     "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.21",
-    "swagger-ui-dist": "4.15.5"
+    "swagger-ui-dist": "5.4.2"
   },
   "jest": {
     "testRegex": "/__tests__/.*-test.(js|jsx)$"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3946,10 +3946,10 @@ supports-color@^3.1.0, supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-swagger-ui-dist@4.15.5:
-  version "4.15.5"
-  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz#cda226a79db2a9192579cc1f37ec839398a62638"
-  integrity sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA==
+swagger-ui-dist@5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-5.4.2.tgz#ff7b936bdfc84673a1823a0f05f3a933ba7ccd4c"
+  integrity sha512-vT5QxP/NOr9m4gLZl+SpavWI3M9Fdh30+Sdw9rEtZbkqNmNNEPhjXas2xTD9rsJYYdLzAiMfwXvtooWH3xbLJA==
 
 symbol-tree@^3.2.1:
   version "3.2.2"


### PR DESCRIPTION
Vi har tatt i bruk 3.1.0 på siste versjonen av apis med tapir. Denne må med for å støtte å vise fra apiene. Sjekk https://api.staging.ndla.no/advanced/swagger?url=/frontpage-api/api-docs